### PR TITLE
Add 'postgres-version' input parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - windows-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run setup-postgres
         uses: ./
@@ -33,6 +33,7 @@ jobs:
           SERVICE_NAME: ${{ steps.postgres.outputs.service-name }}
           EXPECTED_CONNECTION_URI: postgresql://postgres:postgres@localhost:5432/postgres
           EXPECTED_SERVICE_NAME: postgres
+          EXPECTED_SERVER_VERSION: "15"
         shell: bash
 
   parametrized:
@@ -43,8 +44,11 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        postgres-version:
+          - "13"
+          - "14"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run setup-postgres
         uses: ./
@@ -53,6 +57,7 @@ jobs:
           password: GrandMaster
           database: jedi_order
           port: 34837
+          postgres-version: ${{ matrix.postgres-version }}
         id: postgres
 
       - name: Run tests
@@ -64,4 +69,5 @@ jobs:
           SERVICE_NAME: ${{ steps.postgres.outputs.service-name }}
           EXPECTED_CONNECTION_URI: postgresql://yoda:GrandMaster@localhost:34837/jedi_order
           EXPECTED_SERVICE_NAME: yoda
+          EXPECTED_SERVER_VERSION: ${{ matrix.postgres-version }}
         shell: bash

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ key features:
 
 * Runs on Linux, macOS and Windows action runners.
 * Adds PostgreSQL [client applications][1] to `PATH`.
-* Uses PostgreSQL binaries baked into [GitHub Actions Runner Images][2].
-* Easy [to prove][3] that it DOES NOT contain malicious code.
+* Supports PostgreSQL version parametrization.
+* Easy [to prove][2] that it DOES NOT contain malicious code.
+
+By default PostgreSQL 15 is used.
 
 [1]: https://www.postgresql.org/docs/current/reference-client.html
-[2]: https://github.com/actions/runner-images
-[3]: action.yml
+[2]: action.yml
 
 ## Usage
 
@@ -37,19 +38,20 @@ key features:
 
 ```yaml
 steps:
-  - uses: ikalnytskyi/action-setup-postgres@v4
+  - uses: ikalnytskyi/action-setup-postgres@v5
 ```
 
 #### Advanced
 
 ```yaml
 steps:
-  - uses: ikalnytskyi/action-setup-postgres@v4
+  - uses: ikalnytskyi/action-setup-postgres@v5
     with:
       username: ci
       password: sw0rdfish
       database: test
       port: 34837
+      postgres-version: "13"
     id: postgres
 
   - run: pytest -vv tests/
@@ -67,7 +69,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: ikalnytskyi/action-setup-postgres@v4
+  - uses: ikalnytskyi/action-setup-postgres@v5
 
   - run: |
       createuser myuser
@@ -90,7 +92,7 @@ steps:
 
 ```yaml
 steps:
-  - uses: ikalnytskyi/action-setup-postgres@v4
+  - uses: ikalnytskyi/action-setup-postgres@v5
 ```
 
 ```python

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: The server port to listen on.
     default: "5432"
     required: false
+  postgres-version:
+    description: The PostgreSQL version (major) to install. E.g. "13" or "14".
+    default: "15"
+    required: false
 outputs:
   connection-uri:
     description: The connection URI to connect to PostgreSQL.
@@ -31,13 +35,45 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Prerequisites
+    - name: Install PostgreSQL
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
-          echo "$(pg_config --bindir)" >> $GITHUB_PATH
+          echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get -y install postgresql-${{ inputs.postgres-version }}
+
+          # Add PostgreSQL binaries to PATH, so they become globally available.
+          /usr/lib/postgresql/${{ inputs.postgres-version }}/bin/pg_config --bindir >> $GITHUB_PATH
+
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          brew install postgresql@${{ inputs.postgres-version }}
+
+          # Link PostgreSQL binaries to /usr/local/bin so they become globally
+          # available. The overwrite option is required because they might be a
+          # preinstalled linked bottle.
+          brew link --overwrite postgresql@${{ inputs.postgres-version }}
+
         elif [ "$RUNNER_OS" == "Windows" ]; then
-          echo "$PGBIN" >> $GITHUB_PATH
-          echo "PQ_LIB_DIR=$PGROOT\lib" >> $GITHUB_ENV
+          # FIXME: Aargh! For reasons unknown the '--servicename' option is
+          # ignored when installing a PostgreSQL version that is already
+          # preinstalled on GitHub runners. In order to bypass the issue I'm
+          # using default naming convention (i.e. with arch in the name).
+          choco install postgresql${{ inputs.postgres-version }} \
+            --ia "--servicename postgresql-${{ runner.arch }}-${{ inputs.postgres-version }}"
+
+          # Stop PostgreSQL that has been auto started after installation. This
+          # action prepares new configuration and brings its own instance, and
+          # we need a network port to be free.
+          net stop postgresql-${{ runner.arch }}-${{ inputs.postgres-version }}
+
+          # Add PostgreSQL binaries to PATH, so they become globally available
+          # and set path to LIBPQ to link against. On Windows it comes together
+          # with PostgreSQL distribution.
+          export PGROOT="$PROGRAMFILES/PostgreSQL/${{ inputs.postgres-version }}"
+          "$PGROOT"/bin/pg_config.exe --bindir >> $GITHUB_PATH
+          echo "PQ_LIB_DIR=$("$PGROOT"/bin/pg_config.exe --libdir)" >> $GITHUB_ENV
         fi
       shell: bash
 
@@ -65,8 +101,7 @@ runs:
           --pwfile="$PWFILE" \
           --auth="scram-sha-256" \
           --encoding="UTF-8" \
-          --locale="en_US.UTF-8" \
-          --no-instructions
+          --locale="en_US.UTF-8"
 
         # Do not create unix sockets since they are created by default in the
         # directory we have no permissions to (owned by system postgres user).

--- a/test_action.py
+++ b/test_action.py
@@ -84,6 +84,13 @@ def test_locale(connection: psycopg.Connection):
     assert locale.normalize(lc_ctype) == "en_US.UTF-8"
 
 
+def test_server_version(connection: psycopg.Connection):
+    """Test that PostgreSQL's version is expected."""
+
+    server_version = connection.execute("SHOW SERVER_VERSION").fetchone()[0]
+    assert server_version.split(".")[0] == os.getenv("EXPECTED_SERVER_VERSION")
+
+
 def test_user_permissions(connection: psycopg.Connection):
     """Test that a user has super/createdb permissions."""
 


### PR DESCRIPTION
One of the foundational principles of this action was to use preinstalled PostgreSQL binaries. The rationale was simple:

 * Make sure the action is fast and no installation is required.
 * Make sure it's safe and doesn't reach out to external servers.
 * Make sure it's auditable and everyone can verify it contains no malicious code.

It's quite common, however, for applications to follow upstream PostgreSQL releases and switch to them as soon as possible. This applications look to install the latest stable version instead.

This patch adds a new `postgres-version` input parameter that controls what major version of PostgreSQL to install. Please note, the parameter receives only major part of the version, e.g. "14'. It's impossible to request any minor release.

Co-Authored-By: Roman Podoliaka <roman.podoliaka@gmail.com>
Co-Authored-By: Ruslan Kiyanchuk <ruslan.kiyanchuk@gmail.com>

Resolves: #14